### PR TITLE
Add myuw-app-bar-font and fallback search styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-app-styles",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-app-styles",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "This HTML import contains custom CSS properties that are consumed by other components in the myuw-web-components space.",
   "module": "dist/myuw-app-styles.min.mjs",
   "browser": "dist/myuw-app-styles.min.js",

--- a/src/default-app-theme.html
+++ b/src/default-app-theme.html
@@ -15,6 +15,13 @@
   --myuw-darker: #282728;
 
   --myuw-font: 'Roboto', Arial, sans-serif;
+  --myuw-app-bar-font: 'Verlag', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 
+}
+
+/* Duplicate :host styles for search to allow polyfills to work */
+myuw-search {
+  display: flex;
+  flex: auto;
 }
 </style>

--- a/src/myuw-app-styles.js
+++ b/src/myuw-app-styles.js
@@ -20,6 +20,6 @@ let myuwFontFace = new FontFaceObserver('Roboto', {});
 myuwFontFace.load().then(res => {
     document.body.setAttribute('myuw-font-loaded', true);
 }).catch(error => {
-    console.log(error);
     document.body.setAttribute('myuw-font-loaded', true);
+    throw new Error(error);
 });


### PR DESCRIPTION
**In this PR:**
- Set `--myuw-app-bar-font` to Verlag
- Duplicate search `:host` styles to deal with Firefox
- Remove `console.log()` statement