### PR TITLE
Add white theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# myuw-app-styles versions
+
+## 1.2.0
+
+### Added
+
+* `uw-madison-white-theme` adds CSS variables to reskin myuw-web-components for a white theme

--- a/README.md
+++ b/README.md
@@ -12,3 +12,15 @@ Add the app styles script to your document:
 ```
 
 To avoid flashing unstyled text, this component also uses [FontFaceObserver](https://github.com/bramstein/fontfaceobserver) to determine when UW-Madison theme fonts are loaded and updates `<body>` with the attribute `myuw-font-loaded`
+
+## Theming
+
+The default theme is based on UW-Madison red and other colors from the [UW-Madison brand guidelines](https://brand.wisc.edu/web/colors/) for web. You don't have to do anything special to use this theme.
+
+To use the "UW-Madison White" theme, add the "uw-madison-white-theme" class to your page's body element, like so:
+
+```html
+<body class="uw-madison-white-theme">
+    <!-- ... -->
+</body>
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-app-styles",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myuw-web-components/myuw-app-styles",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "This HTML import contains custom CSS properties that are consumed by other components in the myuw-web-components space.",
   "module": "dist/myuw-app-styles.min.mjs",
   "browser": "dist/myuw-app-styles.min.js",

--- a/src/default-app-theme.html
+++ b/src/default-app-theme.html
@@ -17,11 +17,29 @@
   --myuw-font: 'Roboto', Arial, sans-serif;
   --myuw-app-bar-font: 'Verlag', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 
+  --myuw-link-color: #0479a8;
+
+  /* Profile/navigation menu item color */
+  --myuw-menu-color: rgba(0,0,0,0.87);
+
 }
 
 /* Duplicate :host styles for search to allow polyfills to work */
 myuw-search {
   display: flex;
   flex: auto;
+  border: var(--myuw-search-border, none);
+  border-radius: 5px;
+}
+
+/* White theme variables */
+body.uw-madison-white-theme {
+  --myuw-primary-bg: #fff;
+  --myuw-primary-color: #c5050c;
+
+  --myuw-accent-bg: #fff;
+  --myuw-accent-color: #0479a8;
+
+  --myuw-search-border: 1px solid rgba(0,0,0,0.5);
 }
 </style>


### PR DESCRIPTION
**In this PR:**
- Define CSS variables for `<body>` elements with the "uw-madison-white-theme" class
- Add new CSS variables (consumed by various components) to default styles
- Update myuw-search root element styles
- Add a change log file